### PR TITLE
Fix one of the tooltips in settings window

### DIFF
--- a/TimekeeperSettings.cs
+++ b/TimekeeperSettings.cs
@@ -13,7 +13,7 @@
         public bool modEnabled = true;
         public static bool ModEnabled => HighLogic.CurrentGame.Parameters.CustomParams<TimekeeperSettings>().modEnabled;
 
-        [GameParameters.CustomParameterUI("Count Orbits", toolTip = "Enable or disable sols counter")]
+        [GameParameters.CustomParameterUI("Count Orbits", toolTip = "Enable or disable orbits counter")]
         public bool countOrbits = true;
         public static bool CountOrbits => HighLogic.CurrentGame.Parameters.CustomParams<TimekeeperSettings>().countOrbits;
 


### PR DESCRIPTION
The 'Count Orbits' tooltip used to say count sols, now (correctly) says count orbits