### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/Timekeeper/Timekeeper.version
+++ b/GameData/Timekeeper/Timekeeper.version
@@ -1,6 +1,6 @@
 ﻿{
   "NAME": "Timekeeper",
-  "URL": "https://github.com/GarwelGarwel/Timekeeper/raw/master/Timekeeper.version",
+  "URL": "https://github.com/GarwelGarwel/Timekeeper/raw/master/GameData/Timekeeper/Timekeeper.version",
   "DOWNLOAD": "https://github.com/GarwelGarwel/Timekeeper/releases/latest",
   "VERSION": {
     "MAJOR": 1,


### PR DESCRIPTION
The current URL property is missing part of the path, now it's fixed.

Tagging @GarwelGarwel to make sure GitHub sends a notification.

I highly recommend https://github.com/DasSkelett/AVC-VersionFileValidator by @DasSkelett to help with catching issues liek this.